### PR TITLE
docs(readme): fix magicui link

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,6 @@ This project wouldn't be possible without
 - [Cloudflare](https://cloudlfare.com)
 - [Cursor](https://cursor.com)
 - [Claude 3.5 Sonnet by Anthropic](https://anthropic.com/)
-- [MagicUI](https://magicui.com)
+- [MagicUI](https://magicui.design)
 
 And, of course, our open source contributors ❤️


### PR DESCRIPTION
Currently the link isn't going anyware. This PR changes it to the actual link.