### PR TITLE
nit: fix copy code button right margin on desktop devices

### DIFF
--- a/apps/web/components/CopyCodeButton.tsx
+++ b/apps/web/components/CopyCodeButton.tsx
@@ -67,7 +67,7 @@ export const CopyCodeButton = ({
   return (
     <button
       onClick={() => copyCode("button")}
-      className="absolute flex items-center gap-1 top-12 right-2 z-10 p-1 px-2 bg-background text-foreground border border-border rounded-md hover:bg-accent transition-colors md:flex h-8"
+      className="absolute flex items-center gap-1 top-12 right-2 md:right-4 z-10 p-1 px-2 bg-background text-foreground border border-border rounded-md hover:bg-accent transition-colors md:flex h-8"
     >
       {codeCopied ? (
         <>


### PR DESCRIPTION
![CleanShot 2025-01-12 at 11 40 48@2x](https://github.com/user-attachments/assets/999ad90f-8cfb-4a51-ad30-1776cc45184b)

vs on mobile:

![CleanShot 2025-01-12 at 11 41 28@2x](https://github.com/user-attachments/assets/b396bad7-56ba-4e2e-b231-9e7cfa9c72c6)
